### PR TITLE
First spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# metadata-spec
+# OIN Metadata Specification
+
+Any S3 buckets listed in the [Register](https://github.com/openimagerynetwork/register) will need to follow a specification to enable valid indexing within a catalog instance. This repository contains the metadata specification. 
+
+## Sample file
+
+See [sample.json]()
+
+## Specification Description 
+
+| element           | type   | name                    | description                                                                                 | 
+|-------------------|--------|-------------------------|---------------------------------------------------------------------------------------------| 
+| uuid              | string | File                    | unique URI to file                                                                          | 
+| projection        | string | Projection              | CRS of the datasource in full WKT format                                                    | 
+| bbox              | array  | Bounding Box            | Pair of min and max coordinates in CRS units, (min_x, min_y, max_x, max_y)                  | 
+| footprint         | string | Datasource footprint    | WKT format, describing the actual footprint of the imagery                                  | 
+| gsd               | number | Ground Spatial Distance | Average ground spatial distance (resolution) of the datasource imagery, expressed in meters | 
+| file_size         | number | File Size               | File size on disk in bytes                                                                  | 
+| acquisition_start | string | Acquisition Date Start  | First date of acquisition in UTC (Combined date and time representation)                    | 
+| acquisition_end   | string | Acquisition Date End    | Last date of acquisition in UTC (Combined date and time representation) (optional)          | 
+| title             | string | Title                   | Human friendly title of the image                                                           | 
+| platform          | string | Type of imagery         | List of possible platform sources limited to satellite, aircraft, UAV, balloon, kite        | 
+| provider          | string | Imagery Provider        | Provider/owner of the OIN bucket                                                            | 
+| contact           | string | Contact                 | Name and email address of the data provider                                                 | 
+| properties        | object | Properties              | Additional properties about the image (optional)                                            | 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # OIN Metadata Specification
 
-Any S3 buckets listed in the [Register](https://github.com/openimagerynetwork/register) will need to follow a specification to enable valid indexing within a catalog instance. This repository contains the metadata specification. 
+Any S3 buckets listed in the [Register](https://github.com/openimagerynetwork/register) will need to follow a specification to enable valid indexing within a catalog instance. A metadata file is required for each image file in the bucket. An image file is an RGB GeoTIFF.This repository contains the metadata specification. 
 
 ## Sample file
 
-See [sample.json]()
+See [sample.json](sample.json)
 
 ## Specification Description 
 

--- a/sample.json
+++ b/sample.json
@@ -1,0 +1,15 @@
+{
+  "uuid" : "path/to/example.tif",
+  "projection" : "PROJCS["NAD83 / Massachusetts Mainland", ...",
+  "bbox" : [-180,-90,180,90],
+  "footprint" : "POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))",
+  "gsd" : 0.35,
+  "file_size" : 1024,
+  "acquisition_start" : "2015-05-03T13:00:00.000",
+  "acquisition_end" : "2015-05-04T13:00:00.000",
+  "title" : "An scene from some satellite",
+  "platform" : "satellite",
+  "provider" : "Digital Globe",
+  "contact" : "someone@nasa.gov",
+  "properties" : {}
+}


### PR DESCRIPTION
Moving the OIN specifications from the OpenAerialMap repo to within this metadata-spec repo. @kamicut @scisco and I taken another look at the spec and have a couple recommended changes: 
- use full WKT format for Projection
- changed sense_start and sense_end to acquisition to be more understandable 
- added provider element 
- added a properties object 

cc @cholmes @wonderchook @lossyrob @cgiovando -- give a thumbs up if looks good. This will serve as the first version and we can imrpove upon from here as we stand a up a catalog prototype. 

@lossyrob Merge when ready. 
